### PR TITLE
fix(save_model): [0.2.3] Raise exception when saving model without pred data

### DIFF
--- a/buzzwords/buzzwords.py
+++ b/buzzwords/buzzwords.py
@@ -567,6 +567,9 @@ class Buzzwords():
         destination : str
             Location to dump model to
         """
+        if self.prediction_data is False:
+            raise Exception('`prediction_data` is set to false for this model')
+
         destination = Path(destination)
 
         # If file directory was given instead of filename

--- a/buzzwords/model_parameters.yaml
+++ b/buzzwords/model_parameters.yaml
@@ -22,5 +22,5 @@ Buzzwords:
   embedding_batch_size: 128
   matryoshka_decay: 0.8
   keyword_backend: 'keybert'
-  prediction_data: False
+  prediction_data: True
   model_type: 'sentencetransformers'

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,6 @@ import setuptools
 
 setuptools.setup(
     name='buzzwords',
-    version='0.2.2',
+    version='0.2.3',
     packages=setuptools.find_packages()
 )


### PR DESCRIPTION
Buzzwords would throw an AttributeError when you try to save a model with `prediction_data`, make it more intuitive and set `prediction_data` to default to True